### PR TITLE
samples: migrate examples from google-cloud-examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ libraryDependencies += "com.google.cloud" % "google-cloud-nio" % "0.120.0-alpha"
 Example Applications
 -------------------
 
-* [`Stat`](../../../google-cloud-examples/src/main/java/com/google/cloud/examples/nio/Stat.java)
+* [`Stat`](google-cloud-nio-examples/src/main/java/com/google/cloud/examples/nio/Stat.java)
 shows how to get started with NIO.
 
-* [`ParallelCountBytes`](../../../google-cloud-examples/src/main/java/com/google/cloud/examples/nio/ParallelCountBytes.java)
+* [`ParallelCountBytes`](google-cloud-nio-examples/src/main/java/com/google/cloud/examples/nio/ParallelCountBytes.java)
 efficiently downloads a file from Google Cloud Storage.
 
-* [`ListFileSystems`](../google-cloud-nio-examples/README.md) illustrates how
-NIO can add Google Cloud Storage support to some legacy programs, without
+* [`ListFileSystems` retrofit](google-cloud-nio-retrofit/README.md) illustrates
+how NIO can add Google Cloud Storage support to some legacy programs, without
 having to modify them.
 
 
@@ -178,7 +178,7 @@ system implementation. You can disable this feature with
 
 #### Complete source code
 
-There are examples in [google-cloud-examples](../../google-cloud-examples/src/main/java/com/google/cloud/examples/nio/)
+There are examples in [google-cloud-examples](google-cloud-examples/src/main/java/com/google/cloud/examples/nio/)
 for your perusal.
 
 Java Versions

--- a/google-cloud-nio-examples/pom.xml
+++ b/google-cloud-nio-examples/pom.xml
@@ -34,6 +34,13 @@
           <skip>false</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/google-cloud-nio-examples/pom.xml
+++ b/google-cloud-nio-examples/pom.xml
@@ -1,21 +1,29 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>google-cloud-nio-retrofit</artifactId>
+  <artifactId>google-cloud-nio-examples</artifactId>
   <version>0.120.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-nio:current} -->
   <packaging>jar</packaging>
-  <name>Google Cloud NIO Retrofit Example</name>
+  <name>Google Cloud NIO Examples</name>
   <url>https://github.com/googleapis/java-storage-nio</url>
   <description>
-    Demonstrates how to use the google-cloud-nio jar to add Google Cloud Storage functionality to legacy code.
+    Examples for google-cloud-nio (Java idiomatic client for Google Cloud
+    Storage).
   </description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-nio-parent</artifactId>
     <version>0.120.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-nio:current} -->
   </parent>
+  <dependencies>
+    <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>19.0</version>
+    </dependency>
+  </dependencies>
   <properties>
-    <site.installationModule>google-cloud-nio-retrofit</site.installationModule>
+    <site.installationModule>google-cloud-nio-examples</site.installationModule>
   </properties>
   <build>
     <plugins>

--- a/google-cloud-nio-examples/src/main/java/com/google/cloud/examples/nio/CountBytes.java
+++ b/google-cloud-nio-examples/src/main/java/com/google/cloud/examples/nio/CountBytes.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.examples.nio;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.io.BaseEncoding;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * CountBytes will read through the whole file given as input.
+ *
+ * <p>This example shows how to read a file size using NIO. File.size returns the size of the file
+ * as saved in Storage metadata. This class also shows how to read all of the file's contents using
+ * NIO, computes a MD5 hash, and reports how long it took.
+ *
+ * <p>See the <a
+ * href="https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-examples/README.md">
+ * README</a> for compilation instructions. Run this code with
+ *
+ * <pre>{@code target/appassembler/bin/CountBytes <file>}</pre>
+ */
+public class CountBytes {
+
+  /** See the class documentation. */
+  public static void main(String[] args) throws IOException {
+    if (args.length == 0 || args[0].equals("--help")) {
+      help();
+      return;
+    }
+    for (String a : args) {
+      countFile(a);
+    }
+  }
+
+  /**
+   * Print the length of the indicated file.
+   *
+   * <p>This uses the normal Java NIO Api, so it can take advantage of any installed NIO Filesystem
+   * provider without any extra effort.
+   */
+  private static void countFile(String fname) {
+    // large buffers pay off
+    final int bufSize = 50 * 1024 * 1024;
+    try {
+      Path path = Paths.get(new URI(fname));
+      long size = Files.size(path);
+      System.out.println(fname + ": " + size + " bytes.");
+      ByteBuffer buf = ByteBuffer.allocate(bufSize);
+      System.out.println("Reading the whole file...");
+      Stopwatch sw = Stopwatch.createStarted();
+      try (SeekableByteChannel chan = Files.newByteChannel(path)) {
+        long total = 0;
+        int readCalls = 0;
+        MessageDigest md = MessageDigest.getInstance("MD5");
+        while (chan.read(buf) > 0) {
+          readCalls++;
+          md.update(buf.array(), 0, buf.position());
+          total += buf.position();
+          buf.flip();
+        }
+        readCalls++; // We must count the last call
+        long elapsed = sw.elapsed(TimeUnit.SECONDS);
+        System.out.println(
+            "Read all "
+                + total
+                + " bytes in "
+                + elapsed
+                + "s. "
+                + "("
+                + readCalls
+                + " calls to chan.read)");
+        String hex = String.valueOf(BaseEncoding.base16().encode(md.digest()));
+        System.out.println("The MD5 is: 0x" + hex);
+        if (total != size) {
+          System.out.println(
+              "Wait, this doesn't match! We saw "
+                  + total
+                  + " bytes, "
+                  + "yet the file size is listed at "
+                  + size
+                  + " bytes.");
+        }
+      }
+    } catch (Exception ex) {
+      System.out.println(fname + ": " + ex.toString());
+    }
+  }
+
+  private static void help() {
+    String[] help = {"The argument is a <path>", "and we show the length of that file."};
+    for (String s : help) {
+      System.out.println(s);
+    }
+  }
+}

--- a/google-cloud-nio-examples/src/main/java/com/google/cloud/examples/nio/ParallelCountBytes.java
+++ b/google-cloud-nio-examples/src/main/java/com/google/cloud/examples/nio/ParallelCountBytes.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2016 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.examples.nio;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.io.BaseEncoding;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * ParallelCountBytes will read through the whole file given as input.
+ *
+ * <p>This example shows how to go through all the contents of a file, in order, using multithreaded
+ * NIO reads. It prints a MD5 hash and reports how long it took.
+ *
+ * <p>See the <a
+ * href="https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-examples/README.md">
+ * README</a> for compilation instructions. Run this code with
+ *
+ * <pre>{@code target/appassembler/bin/ParallelCountBytes <file>}</pre>
+ */
+public class ParallelCountBytes {
+
+  /**
+   * WorkUnit holds a buffer and the instructions for what to put in it.
+   *
+   * <p>Use it like this:
+   *
+   * <ol>
+   *   <li>call()
+   *   <li>the data is now in buf, you can access it directly
+   *   <li>if need more, call resetForIndex(...) and go back to the top.
+   *   <li>else, call close()
+   * </ol>
+   */
+  private static class WorkUnit implements Callable<WorkUnit>, Closeable {
+    public final ByteBuffer buf;
+    final SeekableByteChannel chan;
+    final int blockSize;
+    int blockIndex;
+
+    public WorkUnit(SeekableByteChannel chan, int blockSize, int blockIndex) {
+      this.chan = chan;
+      this.buf = ByteBuffer.allocate(blockSize);
+      this.blockSize = blockSize;
+      this.blockIndex = blockIndex;
+    }
+
+    @Override
+    public WorkUnit call() throws IOException {
+      long pos = ((long) blockSize) * blockIndex;
+      if (pos > chan.size()) {
+        return this;
+      }
+      chan.position(pos);
+      // read until buffer is full, or EOF
+      while (chan.read(buf) > 0) {}
+      ;
+      return this;
+    }
+
+    public WorkUnit resetForIndex(int blockIndex) {
+      this.blockIndex = blockIndex;
+      buf.flip();
+      return this;
+    }
+
+    public void close() throws IOException {
+      chan.close();
+    }
+  }
+
+  /** See the class documentation. */
+  public static void main(String[] args) throws Exception {
+    if (args.length == 0 || args[0].equals("--help")) {
+      help();
+      return;
+    }
+    for (String a : args) {
+      countFile(a);
+    }
+  }
+
+  /**
+   * Print the length and MD5 of the indicated file.
+   *
+   * <p>This uses the normal Java NIO Api, so it can take advantage of any installed NIO Filesystem
+   * provider without any extra effort.
+   */
+  private static void countFile(String fname) throws Exception {
+    // large buffers pay off
+    final int bufSize = 50 * 1024 * 1024;
+    Queue<Future<WorkUnit>> work = new ArrayDeque<>();
+    Path path = Paths.get(new URI(fname));
+    long size = Files.size(path);
+    System.out.println(fname + ": " + size + " bytes.");
+    int nThreads = (int) Math.ceil(size / (double) bufSize);
+    if (nThreads > 4) nThreads = 4;
+    System.out.println("Reading the whole file using " + nThreads + " threads...");
+    Stopwatch sw = Stopwatch.createStarted();
+    long total = 0;
+    MessageDigest md = MessageDigest.getInstance("MD5");
+
+    ExecutorService exec = Executors.newFixedThreadPool(nThreads);
+    int blockIndex;
+    for (blockIndex = 0; blockIndex < nThreads; blockIndex++) {
+      work.add(exec.submit(new WorkUnit(Files.newByteChannel(path), bufSize, blockIndex)));
+    }
+    while (!work.isEmpty()) {
+      WorkUnit full = work.remove().get();
+      md.update(full.buf.array(), 0, full.buf.position());
+      total += full.buf.position();
+      if (full.buf.hasRemaining()) {
+        full.close();
+      } else {
+        work.add(exec.submit(full.resetForIndex(blockIndex++)));
+      }
+    }
+    exec.shutdown();
+
+    long elapsed = sw.elapsed(TimeUnit.SECONDS);
+    System.out.println("Read all " + total + " bytes in " + elapsed + "s. ");
+    String hex = String.valueOf(BaseEncoding.base16().encode(md.digest()));
+    System.out.println("The MD5 is: 0x" + hex);
+    if (total != size) {
+      System.out.println(
+          "Wait, this doesn't match! We saw "
+              + total
+              + " bytes, "
+              + "yet the file size is listed at "
+              + size
+              + " bytes.");
+    }
+  }
+
+  private static void help() {
+    String[] help = {"The argument is a <path>", "and we show the length of that file."};
+    for (String s : help) {
+      System.out.println(s);
+    }
+  }
+}

--- a/google-cloud-nio-examples/src/main/java/com/google/cloud/examples/nio/Stat.java
+++ b/google-cloud-nio-examples/src/main/java/com/google/cloud/examples/nio/Stat.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.examples.nio;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.spi.FileSystemProvider;
+
+/**
+ * Stat is a super-simple program that just displays the size of the file passed as argument.
+ *
+ * <p>It's meant to be used to test Google Cloud's integration with Java NIO.
+ *
+ * <p>You can either use the '--check' argument to see whether Google Cloud Storage is enabled, or
+ * you can directly pass in a Google Cloud Storage file name to use. In that case you have to be
+ * logged in (using e.g. the gcloud auth command).
+ *
+ * <p>See the <a
+ * href="https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-examples/README.md">
+ * README</a> for compilation instructions. Run this code with
+ *
+ * <pre>{@code target/appassembler/bin/Stat --help | --check | --list | <file>}</pre>
+ *
+ * <p>In short, this version (in google-cloud-examples) is in a package that lists google-cloud-nio
+ * as a dependency, so it will work directly without having to do any special work.
+ */
+public class Stat {
+
+  /** See the class documentation. */
+  public static void main(String[] args) throws IOException {
+    if (args.length == 0 || args[0].equals("--help")) {
+      help();
+      return;
+    }
+    if (args[0].equals("--list")) {
+      listFilesystems();
+      return;
+    }
+    if (args[0].equals("--check")) {
+      checkGcs();
+      return;
+    }
+    for (String a : args) {
+      statFile(a);
+    }
+  }
+
+  /**
+   * Print the length of the indicated file.
+   *
+   * <p>This uses the normal Java NIO Api, so it can take advantage of any installed NIO Filesystem
+   * provider without any extra effort.
+   */
+  private static void statFile(String fname) {
+    try {
+      Path path = Paths.get(new URI(fname));
+      long size = Files.size(path);
+      System.out.println(fname + ": " + size + " bytes.");
+    } catch (Exception ex) {
+      System.out.println(fname + ": " + ex.toString());
+    }
+  }
+
+  private static void help() {
+    String[] help = {
+      "The arguments can be one of:",
+      " * <path>",
+      "   to display the length of that file.",
+      "",
+      " * --list",
+      "   to list the filesystem providers.",
+      "",
+      " * --check",
+      "   to double-check the Google Cloud Storage provider is installed.",
+      "",
+      "The purpose of this tool is to demonstrate that the Google Cloud NIO filesystem provider",
+      "can add Google Cloud Storage support to programs not explicitly designed for it.",
+      "",
+      "This tool normally knows nothing of Google Cloud Storage. If you pass it --check",
+      "or a Google Cloud Storage file name (e.g. gs://mybucket/myfile), it will show an error.",
+      "However, by just adding the google-cloud-nio jar as a dependency and recompiling, this",
+      "tool is made aware of gs:// paths and can access files on the cloud.",
+      "",
+      "The Google Cloud NIO filesystem provider can similarly enable existing Java 7 programs",
+      "to read and write cloud files, even if they have no special built-in cloud support."
+    };
+    for (String s : help) {
+      System.out.println(s);
+    }
+  }
+
+  private static void listFilesystems() {
+    System.out.println("Installed filesystem providers:");
+    for (FileSystemProvider p : FileSystemProvider.installedProviders()) {
+      System.out.println("  " + p.getScheme());
+    }
+  }
+
+  private static void checkGcs() {
+    FileSystem fs = FileSystems.getFileSystem(URI.create("gs://domain-registry-alpha"));
+    System.out.println("Success! We can instantiate a gs:// filesystem.");
+    System.out.println("isOpen: " + fs.isOpen());
+    System.out.println("isReadOnly: " + fs.isReadOnly());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
   <modules>
     <module>google-cloud-nio</module>
     <module>google-cloud-nio-retrofit</module>
+    <module>google-cloud-nio-examples</module>
   </modules>
 
   <reporting>
@@ -245,6 +246,7 @@
       <id>include-samples</id>
       <modules>
         <module>google-cloud-nio-retrofit</module>
+        <module>google-cloud-nio-examples</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
The example links were broken as a result of the repo split.

This PR copies the NIO examples from googleapis/google-cloud-java/google-cloud-examples/
to this repo, and fixes the links. It makes more sense to have the library and the related examples together in the same repository.