### PR TITLE
test: test that Java picks up the NIO provider

### DIFF
--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/NIOTest.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/NIOTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.contrib.nio;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link CloudStorageFileSystemProvider}.
+ *  Makes sure the NIO system picks it up properly. */
+@RunWith(JUnit4.class)
+public class NIOTest {
+
+  private URI uriToCloudStorage;
+
+  @Before
+  public void setUp() {
+    uriToCloudStorage = URI.create("gs://bucket/file.txt");
+  }
+
+  /** We can create a Path object from a gs:// URI. **/
+  @Test
+  public void testCreatePath() {
+    // Return value ignored on purpose, we just want to check
+    // no exception is thrown.
+    Path path = Paths.get(uriToCloudStorage);
+    // Truth bug workaround, see https://github.com/google/truth/issues/285
+    assertThat((Object)path).isNotNull();
+  }
+
+  /** The created Path object has the correct scheme. **/
+  @Test
+  public void testCreatedPathIsGS() {
+    Path path = Paths.get(uriToCloudStorage);
+    assertThat(path.getFileSystem().provider().getScheme()).isEqualTo("gs");
+  }
+
+}

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/NIOTest.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/NIOTest.java
@@ -21,14 +21,15 @@ import static com.google.common.truth.Truth.assertThat;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link CloudStorageFileSystemProvider}.
- *  Makes sure the NIO system picks it up properly. */
+/**
+ * Unit tests for {@link CloudStorageFileSystemProvider}. Makes sure the NIO system picks it up
+ * properly.
+ */
 @RunWith(JUnit4.class)
 public class NIOTest {
 
@@ -39,21 +40,20 @@ public class NIOTest {
     uriToCloudStorage = URI.create("gs://bucket/file.txt");
   }
 
-  /** We can create a Path object from a gs:// URI. **/
+  /** We can create a Path object from a gs:// URI. * */
   @Test
   public void testCreatePath() {
     // Return value ignored on purpose, we just want to check
     // no exception is thrown.
     Path path = Paths.get(uriToCloudStorage);
     // Truth bug workaround, see https://github.com/google/truth/issues/285
-    assertThat((Object)path).isNotNull();
+    assertThat((Object) path).isNotNull();
   }
 
-  /** The created Path object has the correct scheme. **/
+  /** The created Path object has the correct scheme. * */
   @Test
   public void testCreatedPathIsGS() {
     Path path = Paths.get(uriToCloudStorage);
     assertThat(path.getFileSystem().provider().getScheme()).isEqualTo("gs");
   }
-
 }


### PR DESCRIPTION
Make sure we find the provider and it recognizes paths as expected.
These tests don't actually connect to any Google Cloud Storage
bucket.

cf. https://github.com/googleapis/google-cloud-java/pull/7082