### PR TITLE
fix(test): update NIOTest to ensure LocalStorageHelper is used

### DIFF
--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/NIOTest.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/NIOTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.storage.contrib.nio;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import java.net.URI;
 import java.nio.file.Path;
@@ -40,6 +41,7 @@ public class NIOTest {
 
   @Before
   public void setUp() {
+    CloudStorageFileSystemProvider.setStorageOptions(LocalStorageHelper.getOptions());
     uriToCloudStorage = URI.create("gs://bucket/file.txt");
   }
 


### PR DESCRIPTION
When starting a test, there is a `gs://` uri which is referenced before any unit test level configuration of CloudStorageFileSystemProvider. If NIOTest runs as the first test in the JVM, CloudStorageFileSystemProvider will initialize internally using all default options (which are production endpoints).

This fix ensures that before the `gs://` uri is resolved in the NIOTests that LocalStorageHelper is configured rather than defaults.

