### PR TITLE
deps: update google-cloud-* libraries to v2

### DIFF
--- a/google-cloud-nio/pom.xml
+++ b/google-cloud-nio/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
-      <version>1.94.8</version>
+      <version>2.0.2</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>1.4.0</version>
+        <version>2.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -78,7 +78,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-storage</artifactId>
-        <version>1.118.0</version>
+        <version>2.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.apis</groupId>
@@ -102,6 +102,12 @@
         <artifactId>truth</artifactId>
         <version>1.1.3</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
* update dependency com.google.cloud:google-cloud-shared-dependencies to v2.0.0
* update dependency com.google.cloud:google-cloud-core:test to v2.0.2
* update dependency com.google.cloud:google-cloud-storage to v2.0.0

Replaces #628, #632, #638