### PR TITLE
Fix requester pays check#824

### DIFF
--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
@@ -87,6 +87,8 @@ import javax.inject.Singleton;
 @ThreadSafe
 public final class CloudStorageFileSystemProvider extends FileSystemProvider {
 
+  public static final String BUCKET_IS_REQUESTER_PAYS_ERROR_MESSAGE =
+      "Bucket is a requester pays bucket but no user project provided";
   private Storage storage;
   private final StorageOptions storageOptions;
   // if non-null, we pay via this project.
@@ -967,7 +969,7 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
       Boolean isRP = storage.get(bucketName).requesterPays();
       return isRP != null && isRP.booleanValue();
     } catch (StorageException ex) {
-      if (ex.getCode() == 400 && ex.getMessage().contains("Bucket is requester pays")) {
+      if (ex.getCode() == 400 && ex.getMessage().contains(BUCKET_IS_REQUESTER_PAYS_ERROR_MESSAGE)) {
         return true;
       }
       throw ex;

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
@@ -288,7 +288,7 @@ public class ITGcsNio {
       Assert.assertTrue(
           description,
           hex.getMessage()
-              .contains("Bucket is requester pays bucket but no user project provided"));
+              .contains(CloudStorageFileSystemProvider.BUCKET_IS_REQUESTER_PAYS_ERROR_MESSAGE));
     } catch (StorageException ex) {
       assertIsRequesterPaysException(description, ex);
     }
@@ -342,14 +342,16 @@ public class ITGcsNio {
     Assert.assertEquals(message, ex.getCode(), 400);
     Assert.assertTrue(
         message,
-        ex.getMessage().contains("Bucket is requester pays bucket but no user project provided"));
+        ex.getMessage()
+            .contains(CloudStorageFileSystemProvider.BUCKET_IS_REQUESTER_PAYS_ERROR_MESSAGE));
   }
 
   private void assertIsRequesterPaysException(String message, IOException ioex) {
     Assert.assertTrue(message, ioex.getMessage().startsWith("400"));
     Assert.assertTrue(
         message,
-        ioex.getMessage().contains("Bucket is requester pays bucket but no user project provided"));
+        ioex.getMessage()
+            .contains(CloudStorageFileSystemProvider.BUCKET_IS_REQUESTER_PAYS_ERROR_MESSAGE));
   }
   // End of tests related to the "requester pays" feature
 

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
@@ -75,7 +75,6 @@ import java.util.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -176,7 +175,6 @@ public class ITGcsNio {
 
   // Start of tests related to the "requester pays" feature
   @Test
-  @Ignore("TODO: https://github.com/googleapis/java-storage-nio/issues/824")
   public void testFileExistsRequesterPaysNoUserProject() throws IOException {
     CloudStorageFileSystem testBucket = getRequesterPaysBucket(false, "");
     Path path = testBucket.getPath(SML_FILE);
@@ -190,7 +188,6 @@ public class ITGcsNio {
   }
 
   @Test
-  @Ignore("TODO: https://github.com/googleapis/java-storage-nio/issues/824")
   public void testFileExistsRequesterPays() throws IOException {
     CloudStorageFileSystem testBucket = getRequesterPaysBucket(false, project);
     Path path = testBucket.getPath(SML_FILE);
@@ -199,7 +196,6 @@ public class ITGcsNio {
   }
 
   @Test
-  @Ignore("TODO: https://github.com/googleapis/java-storage-nio/issues/824")
   public void testFileExistsRequesterPaysWithAutodetect() throws IOException {
     CloudStorageFileSystem testBucket = getRequesterPaysBucket(true, project);
     Path path = testBucket.getPath(SML_FILE);
@@ -208,7 +204,6 @@ public class ITGcsNio {
   }
 
   @Test
-  @Ignore("TODO: https://github.com/googleapis/java-storage-nio/issues/824")
   public void testCantCreateWithoutUserProject() throws IOException {
     CloudStorageFileSystem testBucket = getRequesterPaysBucket(false, "");
     Path path = testBucket.getPath(TMP_FILE);
@@ -230,7 +225,6 @@ public class ITGcsNio {
   }
 
   @Test
-  @Ignore("TODO: https://github.com/googleapis/java-storage-nio/issues/824")
   public void testCantReadWithoutUserProject() throws IOException {
     CloudStorageFileSystem testBucket = getRequesterPaysBucket(false, "");
     Path path = testBucket.getPath(SML_FILE);
@@ -252,7 +246,6 @@ public class ITGcsNio {
   }
 
   @Test
-  @Ignore("TODO: https://github.com/googleapis/java-storage-nio/issues/824")
   public void testCantCopyWithoutUserProject() throws IOException {
     CloudStorageFileSystem testRPBucket = getRequesterPaysBucket(false, "");
     CloudStorageFileSystem testBucket = getTestBucket();
@@ -314,7 +307,6 @@ public class ITGcsNio {
   }
 
   @Test
-  @Ignore("TODO: https://github.com/googleapis/java-storage-nio/issues/824")
   public void testAutodetectWhenRequesterPays() throws IOException {
     CloudStorageFileSystem testRPBucket = getRequesterPaysBucket(true, project);
     Assert.assertEquals(


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-storage-nio/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass <- Normal tests and linter pass but I was unable to configure a service account correctly to pass the integration tests.
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #824 ☕️


* The error message received when querying for requester pays status changed to include an 'a' which caused strict matching to fail. 
* This fixes and standardizes the error message to use the same string for both the code and the tests.
