### PR TITLE
fix: prevent NPE when checking requester pays status

### DIFF
--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
@@ -967,10 +967,12 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
       Boolean isRP = storage.get(bucketName).requesterPays();
       return isRP != null && isRP.booleanValue();
     } catch (StorageException ex) {
-      if (ex.getReason().equals("userProjectMissing")) {
+      if ("userProjectMissing".equals(ex.getReason())) {
         return true;
         // fallback to checking the error code and error message.
-      } else if (ex.getCode() == 400 && ex.getMessage().contains("requester pays")) {
+      } else if (ex.getCode() == 400
+          && ex.getMessage() != null
+          && ex.getMessage().contains("requester pays")) {
         return true;
       }
       throw ex;


### PR DESCRIPTION
Fixes a NullPointerException introduced in #841 which occured when trying
to check the the requesterPays status of a file while authenticated with an
invalid service account.

Refs: #849, #841

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-storage-nio/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #849 ☕️