### PR TITLE
fix: prevent crash when checking if a missing file exists #856

### DIFF
--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageConfiguration.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageConfiguration.java
@@ -123,7 +123,7 @@ public abstract class CloudStorageConfiguration {
     private int blockSize = CloudStorageFileSystem.BLOCK_SIZE_DEFAULT;
     private int maxChannelReopens = 0;
     private @Nullable String userProject = null;
-    // This of this as "clear userProject if not RequesterPays"
+    // Think of this as "clear userProject if not RequesterPays"
     private boolean useUserProjectOnlyForRequesterPaysBuckets = false;
     private ImmutableList<Integer> retryableHttpCodes = ImmutableList.of(500, 502, 503);
     private ImmutableList<Class<? extends Exception>> reopenableExceptions =

--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStoragePath.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStoragePath.java
@@ -23,6 +23,7 @@ import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
+import com.google.common.base.Strings;
 import com.google.common.collect.UnmodifiableIterator;
 import java.io.File;
 import java.net.URI;
@@ -113,7 +114,7 @@ public final class CloudStoragePath implements Path {
     }
     String userProject = fileSystem.config().userProject();
     Page<Blob> list = null;
-    if (userProject != null) {
+    if (!Strings.isNullOrEmpty(userProject)) {
       list =
           storage.list(
               this.bucket(),

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
@@ -328,6 +328,18 @@ public class ITGcsNio {
   }
 
   @Test
+  public void testFilesExistDoesntCrashWhenRequesterPays() throws IOException {
+    CloudStorageConfiguration config =
+        CloudStorageConfiguration.builder()
+            .autoDetectRequesterPays(true)
+            .userProject(project)
+            .build();
+    CloudStorageFileSystem testBucket =
+        CloudStorageFileSystem.forBucket(BUCKET, config, storageOptions);
+    Assert.assertFalse(Files.exists(testBucket.getPath("path")));
+  }
+
+  @Test
   public void testAutoDetectNoUserProject() throws IOException {
     CloudStorageFileSystem testBucket = getRequesterPaysBucket(false, "");
     Assert.assertTrue(testBucket.provider().requesterPays(testBucket.bucket()));


### PR DESCRIPTION
Fixes a crash that occurred when autoDetectRequesterPays is set and
a Files.exists() call is made on a file that doesn't exist.

Refs: #856

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-storage-nio/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea 
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #856 ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
