### PR TITLE
fix: Prevent NPE when bucket doesn't exist #857

### DIFF
--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
@@ -963,8 +963,13 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
   public boolean requesterPays(String bucketName) {
     initStorage();
     try {
-      // instead of true/false, this method returns true/null.
-      Boolean isRP = storage.get(bucketName).requesterPays();
+      final Bucket bucket = storage.get(bucketName);
+      // If the bucket doesn't exist it can't be requester pays.
+      if (bucket == null) {
+        return false;
+      }
+      // instead of true/false, this method returns true/null
+      Boolean isRP = bucket.requesterPays();
       return isRP != null && isRP.booleanValue();
     } catch (StorageException ex) {
       if ("userProjectMissing".equals(ex.getReason())) {

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
@@ -344,7 +344,6 @@ public class ITGcsNio {
     Assert.assertEquals(
         aPathThatDoesntExist.toUri().toString(), "gs://" + bucketThatDoesntExist + "/" + subPath);
     Assert.assertFalse(testBucket.provider().requesterPays(bucketThatDoesntExist));
-
   }
 
   @Test

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
@@ -49,6 +49,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
@@ -325,6 +326,24 @@ public class ITGcsNio {
         "Autodetect should have detected the bucket is not RP",
         testBucket.config().userProject(),
         "");
+  }
+
+  @Test
+  public void assertNoCrashWhenBucketDoesntExist() throws URISyntaxException {
+    CloudStorageConfiguration config =
+        CloudStorageConfiguration.builder()
+            .autoDetectRequesterPays(true)
+            .userProject(project)
+            .usePseudoDirectories(true)
+            .build();
+
+    final String bucketThatDoesntExist = "abuckethatdoesntexist";
+    final String subPath = "hello";
+    CloudStorageFileSystem testBucket =
+        CloudStorageFileSystem.forBucket(bucketThatDoesntExist, config, storageOptions);
+    final CloudStoragePath aPathThatDoesntExist = testBucket.getPath(subPath);
+    Assert.assertEquals(
+        aPathThatDoesntExist.toUri().toString(), "gs://" + bucketThatDoesntExist + "/" + subPath);
   }
 
   @Test

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
@@ -347,6 +347,18 @@ public class ITGcsNio {
   }
 
   @Test
+  public void testFilesExistBehaviorRequesterPays() {
+    CloudStorageConfiguration config =
+        CloudStorageConfiguration.builder()
+            .autoDetectRequesterPays(true)
+            .userProject(project)
+            .build();
+    CloudStorageFileSystem testBucket =
+        CloudStorageFileSystem.forBucket(BUCKET, config, storageOptions);
+    Assert.assertFalse(Files.exists(testBucket.getPath("path")));
+  }
+
+  @Test
   public void testAutoDetectNoUserProject() throws IOException {
     CloudStorageFileSystem testBucket = getRequesterPaysBucket(false, "");
     Assert.assertTrue(testBucket.provider().requesterPays(testBucket.bucket()));

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
@@ -49,7 +49,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
@@ -329,7 +329,7 @@ public class ITGcsNio {
   }
 
   @Test
-  public void assertNoCrashWhenBucketDoesntExist() throws URISyntaxException {
+  public void testRequesterPaysOnNonexistentBucket() {
     CloudStorageConfiguration config =
         CloudStorageConfiguration.builder()
             .autoDetectRequesterPays(true)
@@ -344,6 +344,7 @@ public class ITGcsNio {
     final CloudStoragePath aPathThatDoesntExist = testBucket.getPath(subPath);
     Assert.assertEquals(
         aPathThatDoesntExist.toUri().toString(), "gs://" + bucketThatDoesntExist + "/" + subPath);
+    Assert.assertFalse(testBucket.provider().requesterPays(bucketThatDoesntExist));
   }
 
   @Test


### PR DESCRIPTION
Fixes a NullPointerException when creating a Path object with a bucket
that doesn't exist. This only occurred when autoDetectRequesterPays = true.

Refs: #857

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-storage-nio/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #857☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
