### PR TITLE
fix: Files.exist() will now always return false for buckets that don't exist.

### DIFF
--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
@@ -726,6 +726,11 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
     // Loop will terminate via an exception if all retries are exhausted
     while (true) {
       try {
+        // first check that the bucket exists
+        if (!bucketExists(cloudPath.bucket())) {
+          throw new NoSuchFileException(path.toString());
+        }
+
         boolean nullId;
         if (isNullOrEmpty(userProject)) {
           nullId =
@@ -762,6 +767,15 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
         throw exs;
       }
     }
+  }
+
+  // This helper method does not perform it's own retries
+  private boolean bucketExists(final String bucketName) {
+    final Bucket bucket =
+        isNullOrEmpty(userProject)
+            ? storage.get(bucketName)
+            : storage.get(bucketName, Storage.BucketGetOption.userProject(userProject));
+    return bucket != null;
   }
 
   @Override

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
@@ -49,6 +49,8 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
@@ -59,6 +61,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
@@ -1187,5 +1190,13 @@ public class ITGcsNio {
             .userProject(userProject)
             .build();
     return CloudStorageFileSystem.forBucket(REQUESTER_PAYS_BUCKET, config, storageOptions);
+  }
+
+  @Test
+  public void testBucketsThatDontExistDontExist() throws URISyntaxException {
+    Assert.assertFalse(Files.exists(Paths.get(new URI("gs://bucketthatdoesntexist"))));
+    Assert.assertFalse(Files.exists(Paths.get(new URI("gs://bucketthatdoesntexist/"))));
+    Assert.assertFalse(Files.exists(Paths.get(new URI("gs://bucketthatdoesntexist/a"))));
+    Assert.assertFalse(Files.exists(Paths.get(new URI("gs://bucketthatdoesntexist/a/"))));
   }
 }


### PR DESCRIPTION
@sydney-munro Here's a potential solution to #859 which makes sense to me.  The implementation could probably be improved since this adds an extra request in many cases. 

It might also make more sense to replace the NoSuchFileException here with a more specific IOException like BucketDoesNotExistException which will be handled appropriately by calling code that understands IOException.  Adding a new runtime exception here (like FileSystemNotFoundException) would cause issues since Files.exists() and potentially other methods have special handling for the IOExceptions.


Previously Files.exist() would either crash with a StorageException or return true when
checking a path that to a bucket that doesn't exist.  This is technically a breaking change
since previously all paths that ended in / were considered to exist when usePseudoDirectories
was set.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-storage-nio/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary) <- I haven't touched these yet.

Fixes #859   ☕️
