### PR TITLE
fix(java): initialize classes at build-time to fix Native Image compilation

### DIFF
--- a/google-cloud-nio/src/main/resources/META-INF/native-image/com/google/cloud/google-cloud-nio/native-image.properties
+++ b/google-cloud-nio/src/main/resources/META-INF/native-image/com/google/cloud/google-cloud-nio/native-image.properties
@@ -35,4 +35,9 @@ Args = --initialize-at-build-time=com.google.cloud.storage.contrib.nio.CloudStor
   com.google.api.client.json.JsonParser$1,\
   com.google.cloud.PlatformInformation,\
   com.google.cloud.ExceptionHandler,\
-  org.threeten.bp.Duration
+  org.threeten.bp.Duration,\
+  com.google.common.io.BaseEncoding$Base16Encoding,\
+  com.google.common.io.BaseEncoding$Base64Encoding,\
+  com.google.common.io.BaseEncoding,\
+  com.google.common.io.BaseEncoding$StandardBaseEncoding,\
+  com.google.api.client.util.PemReader

--- a/google-cloud-nio/src/main/resources/META-INF/native-image/com/google/cloud/google-cloud-nio/native-image.properties
+++ b/google-cloud-nio/src/main/resources/META-INF/native-image/com/google/cloud/google-cloud-nio/native-image.properties
@@ -1,0 +1,36 @@
+# Using META-INF/services with Native Image compilation results in
+# FileSystemProvider being initialized at build time. This results
+# CloudStorageFileSystemProvider and all the sub-classes referenced by
+# this class also being initialized at build time.
+Args = --initialize-at-build-time=com.google.cloud.storage.contrib.nio.CloudStorageFileSystemProvider,\
+  com.google.cloud.storage.contrib.nio.CloudStorageConfiguration,\
+  com.google.cloud.storage.contrib.nio.CloudStorageFileSystem,\
+  com.google.cloud.storage.contrib.nio.StorageOptionsUtil,\
+  com.google.cloud.storage.StorageException,\
+  com.google.cloud.storage.StorageOptions,\
+  com.google.cloud.storage.DefaultStorageRetryStrategy,\
+  com.google.api.client.http.OpenCensusUtils,\
+  com.google.api.client.http.GenericUrl,\
+  com.google.api.client.http.HttpRequest,\
+  com.google.api.client.http.HttpMediaType,\
+  com.google.api.client.http.javanet.NetHttpTransport,\
+  com.google.api.client.util.Data,\
+  com.google.api.client.util.DateTime,\
+  com.google.auth.oauth2,\
+  io.opencensus.trace,\
+  com.google.api.client.util.escape.CharEscapers,\
+  com.google.api.client.util.escape.PercentEscaper,\
+  io.opencensus.contrib.http.util.CloudTraceFormat,\
+  io.grpc.Context,\
+  io.grpc.Context$LazyStorage,\
+  io.grpc.ThreadLocalContextStorage,\
+  com.google.common.cache.LocalCache,\
+  com.google.common.cache.CacheBuilder,\
+  com.google.common.math.IntMath$1,\
+  com.google.common.collect.RegularImmutableMap,\
+  com.google.gson.stream.JsonReader,\
+  com.google.api.client.json.gson.GsonParser$1,\
+  com.google.api.client.json.JsonParser$1,\
+  com.google.cloud.PlatformInformation,\
+  com.google.cloud.ExceptionHandler,\
+  org.threeten.bp.Duration

--- a/google-cloud-nio/src/main/resources/META-INF/native-image/com/google/cloud/google-cloud-nio/native-image.properties
+++ b/google-cloud-nio/src/main/resources/META-INF/native-image/com/google/cloud/google-cloud-nio/native-image.properties
@@ -1,7 +1,9 @@
 # Using META-INF/services with Native Image compilation results in
 # FileSystemProvider being initialized at build time. This results
-# CloudStorageFileSystemProvider and all the sub-classes referenced by
-# this class also being initialized at build time.
+# CloudStorageFileSystemProvider and some classes referenced by
+# this class (for example, StorageOptions, StorageOptionsUtil,
+# DefaultStorageRetryStrategy) being unexpectedly and recursively initialized at
+# build time.
 Args = --initialize-at-build-time=com.google.cloud.storage.contrib.nio.CloudStorageFileSystemProvider,\
   com.google.cloud.storage.contrib.nio.CloudStorageConfiguration,\
   com.google.cloud.storage.contrib.nio.CloudStorageFileSystem,\


### PR DESCRIPTION
Using META-INF/services with Native Image compilation causes the `FileSystemProvider` class to be initialized at build time. This causes `com.google.cloud.storage.contrib.nio.CloudStorageFileSystemProvider` and a couple of unexpected classes that are referenced to also be initialized at build time. 
