### PR TITLE
replace HashMap with ConcurrentHashMap to avoid ConcurrentModificatio…

### DIFF
--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/testing/FakeStorageRpc.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/testing/FakeStorageRpc.java
@@ -37,6 +37,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -77,11 +78,11 @@ class FakeStorageRpc extends StorageRpcTestBase {
       new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
 
   // fullname -> metadata
-  Map<String, StorageObject> metadata = new HashMap<>();
+  Map<String, StorageObject> metadata = new ConcurrentHashMap<>();
   // fullname -> contents
-  Map<String, byte[]> contents = new HashMap<>();
+  Map<String, byte[]> contents = new ConcurrentHashMap<>();
   // fullname -> future contents that will be visible on close.
-  Map<String, byte[]> futureContents = new HashMap<>();
+  Map<String, byte[]> futureContents = new ConcurrentHashMap<>();
 
   private final boolean throwIfOption;
 
@@ -92,8 +93,8 @@ class FakeStorageRpc extends StorageRpcTestBase {
 
   // remove all files
   void reset() {
-    metadata = new HashMap<>();
-    contents = new HashMap<>();
+    metadata = new ConcurrentHashMap<>();
+    contents = new ConcurrentHashMap<>();
   }
 
   @Override
@@ -149,7 +150,7 @@ class FakeStorageRpc extends StorageRpcTestBase {
     final String prefix = preprefix;
 
     List<StorageObject> values = new ArrayList<>();
-    Map<String, StorageObject> folders = new HashMap<>();
+    Map<String, StorageObject> folders = new ConcurrentHashMap<>();
     for (StorageObject so : metadata.values()) {
       if (!so.getBucket().equals(bucket) || !so.getName().startsWith(prefix)) {
         continue;

--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/testing/FakeStorageRpc.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/testing/FakeStorageRpc.java
@@ -34,7 +34,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;


### PR DESCRIPTION
replace HashMap with ConcurrentHashMap to avoid ConcurrentModificationException

avoids this exception:
```
Caused by: java.lang.RuntimeException: java.util.ConcurrentModificationException with message: null
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1511)
	at java.util.HashMap$ValueIterator.next(HashMap.java:1539)
	at com.google.cloud.storage.contrib.nio.testing.FakeStorageRpc.list(FakeStorageRpc.java:153)
	at com.google.cloud.storage.StorageImpl.lambda$listBlobs$11(StorageImpl.java:391)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:105)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
	at com.google.cloud.storage.Retrying.run(Retrying.java:51)
```

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-storage-nio/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
