### PR TITLE
fix(build): revert maven-shade-plugin 3.3.0

### DIFF
--- a/google-cloud-nio/pom.xml
+++ b/google-cloud-nio/pom.xml
@@ -104,7 +104,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.3.0</version>
+        <!-- MSHADE-419: 3.3.0 Shade plugin causes pom to be created without compile dependencies -->
+        <version>3.2.4</version>
         <configuration>
           <shadedArtifactAttached>true</shadedArtifactAttached>
           <relocations>

--- a/owlbot.py
+++ b/owlbot.py
@@ -21,4 +21,4 @@ for library in s.get_staging_dirs():
     s.move(library)
 
 s.remove_staging_dirs()
-java.common_templates(excludes=["README.md", ".kokoro/build.sh"])
+java.common_templates(excludes=["README.md", ".kokoro/build.sh", "renovate.json"])

--- a/renovate.json
+++ b/renovate.json
@@ -67,6 +67,12 @@
         "^com.fasterxml.jackson.core"
       ],
       "groupName": "jackson dependencies"
+    },
+    {
+      "packagePatterns": [
+        "^org.apache.maven.plugins:maven-shade-plugin"
+      ],
+      "allowedVersions": "(,3.3.0),(3.3.0,)"
     }
   ],
   "semanticCommits": true,


### PR DESCRIPTION
Due to a bug in maven shade plugin 3.3.0, compile dependencies got stripped from `google-cloud-nio:shaded`. This bug only affects artifacts where shadedArtifactAttached=true.

Related: https://github.com/googleapis/java-bigtable-hbase/pull/3600
Reference: https://issues.apache.org/jira/projects/MSHADE/issues/MSHADE-419