### PR TITLE
WIP Change CloudStorageFileSystemProvider.getPath to check the existence of a bucket

### DIFF
--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
@@ -268,9 +268,10 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
   @Override
   public CloudStoragePath getPath(URI uri) {
     initStorage();
-    CloudStoragePath cloudStoragePath = CloudStoragePath.getPath(
-        getFileSystem(CloudStorageUtil.stripPathFromUri(uri)), uri.getPath());
-    if(storage.get(cloudStoragePath.bucket()) == null) {
+    CloudStoragePath cloudStoragePath =
+        CloudStoragePath.getPath(
+            getFileSystem(CloudStorageUtil.stripPathFromUri(uri)), uri.getPath());
+    if (storage.get(cloudStoragePath.bucket()) == null) {
       throw new FileSystemNotFoundException(
           "Bucket " + cloudStoragePath.bucket() + "does not exist");
     }

--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
@@ -51,6 +51,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.DirectoryStream.Filter;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileStore;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
@@ -267,8 +268,13 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
   @Override
   public CloudStoragePath getPath(URI uri) {
     initStorage();
-    return CloudStoragePath.getPath(
+    CloudStoragePath cloudStoragePath = CloudStoragePath.getPath(
         getFileSystem(CloudStorageUtil.stripPathFromUri(uri)), uri.getPath());
+    if(storage.get(cloudStoragePath.bucket()) == null) {
+      throw new FileSystemNotFoundException(
+          "Bucket " + cloudStoragePath.bucket() + "does not exist");
+    }
+    return cloudStoragePath;
   }
 
   /** Convenience method: replaces spaces with "%20", builds a URI, and calls getPath(uri). */

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/it/ITGcsNio.java
@@ -49,16 +49,20 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
@@ -1174,6 +1178,42 @@ public class ITGcsNio {
     } finally {
       Files.deleteIfExists(foo);
       Files.deleteIfExists(bar);
+    }
+  }
+
+  @Test
+  public void testNonexistantBucketFileExistsBlob() throws URISyntaxException {
+    try {
+      Files.exists(Paths.get(new URI("gs://bucketthatdoesntexist/thing")));
+      Assert.fail("It should have thrown an exception.");
+    } catch (FileSystemNotFoundException ex) {
+      // What we want
+    } catch (Exception e) {
+      Assert.fail("Should have been a FileSystemNotFoundException");
+    }
+  }
+
+  @Test
+  public void testNonexistantBucketFileExistsDirectory() throws URISyntaxException {
+    try {
+      Files.exists(Paths.get(new URI("gs://bucketthatdoesntexist/thing/")));
+      Assert.fail("It should have thrown an exception.");
+    } catch (FileSystemNotFoundException ex) {
+      // What we want
+    } catch (Exception e) {
+      Assert.fail("Should have been a FileSystemNotFoundException");
+    }
+  }
+
+  @Test
+  public void testNonexistantBucketFileExistsRoot() throws URISyntaxException {
+    try {
+      Files.exists(Paths.get(new URI("gs://bucketthatdoesntexist")));
+      Assert.fail("It should have thrown an exception.");
+    } catch (FileSystemNotFoundException ex) {
+      // What we want
+    } catch (Exception e) {
+      Assert.fail("Should have been a FileSystemNotFoundException");
     }
   }
 


### PR DESCRIPTION
This is a WIP for feedback on the approach here before digging in and fixing all the tests this change has broken.

After reading through the Java docs it seems most appropriate here to check for the existence of the bucket when resolving the path in the FileSystemProvider, since the file system, identified by the URI, does not exist and cannot be created automatically. See [java docs](https://docs.oracle.com/javase/7/docs/api/java/nio/file/spi/FileSystemProvider.html#getPath(java.net.URI)).

This solves the File.exists problem by creating a consistent experience no matter if we are calling it on a bucket, a directory or a file, if the bucket does not exist then the Paths.get call will fail. 

Fixes #859  ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
