### PR TITLE
chore: exclude maven-shade-plugin v3.4.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,7 +72,7 @@
       "packagePatterns": [
         "^org.apache.maven.plugins:maven-shade-plugin"
       ],
-      "allowedVersions": "(,3.3.0),(3.3.0,)"
+      "allowedVersions": "(,3.3.0),(3.4.0,)"
     }
   ],
   "semanticCommits": true,


### PR DESCRIPTION
maven-shade-plugin does not yet fix
https://issues.apache.org/jira/projects/MSHADE/issues/MSHADE-419
