### PR TITLE
chore: exclude requirements.txt file from renovate-bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     ":maintainLockFilesDisabled",
     ":autodetectPinVersions"
   ],
+  "ignorePaths": [".kokoro/requirements.txt"],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
Port of https://github.com/googleapis/synthtool/pull/1594 due to renovate.json being excluded from template in this repo.

