### PR TITLE
feat: FileSystemProvider::readAttributes faked posix support

### DIFF
--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystem.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystem.java
@@ -64,9 +64,11 @@ public final class CloudStorageFileSystem extends FileSystem {
   public static final String URI_SCHEME = "gs";
   public static final String GCS_VIEW = "gcs";
   public static final String BASIC_VIEW = "basic";
+  public static final String POSIX_VIEW = "posix";
   public static final int BLOCK_SIZE_DEFAULT = 2 * 1024 * 1024;
   public static final FileTime FILE_TIME_UNKNOWN = FileTime.fromMillis(0);
-  public static final Set<String> SUPPORTED_VIEWS = ImmutableSet.of(BASIC_VIEW, GCS_VIEW);
+  public static final Set<String> SUPPORTED_VIEWS =
+      ImmutableSet.of(BASIC_VIEW, GCS_VIEW, POSIX_VIEW);
   private final CloudStorageFileSystemProvider provider;
   private final String bucket;
   private final CloudStorageConfiguration config;

--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
@@ -19,6 +19,12 @@ package com.google.cloud.storage.contrib.nio;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 
 import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Acl;
@@ -62,10 +68,13 @@ import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -847,7 +856,7 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
     //             (eg. BasicFileAttributeView and PosixFileAttributeView), so rather than a partial
     //             implementation we rely on the other overload for now.
 
-    // Partial implementation for a few commonly used ones: basic, gcs
+    // Partial implementation for a few commonly used ones: basic, gcs, posix
     String[] split = attributes.split(":", 2);
     if (split.length != 2) {
       throw new UnsupportedOperationException();
@@ -863,6 +872,9 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
       case "gcs":
         fileAttributes = readAttributes(path, CloudStorageFileAttributes.class, options);
         break;
+      case "posix":
+        // There is no real support for posix.
+        // Some systems expect Posix support for everything so these attributes are faked.
       case "basic":
         fileAttributes = readAttributes(path, BasicFileAttributes.class, options);
         break;
@@ -898,6 +910,53 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
     }
     if (allAttributes || attributeNames.contains("size")) {
       results.put("size", fileAttributes.size());
+    }
+
+    // There is no real support for posix.
+    // Some systems fail if there is no posix support at all.
+    // To let these systems use this FileSystem these attributes are faked.
+    if (view.equals("posix")) {
+      if (allAttributes || attributeNames.contains("owner")) {
+        results.put(
+            "owner",
+            new UserPrincipal() {
+              @Override
+              public String getName() {
+                return "fakeowner";
+              }
+
+              @Override
+              public String toString() {
+                return "fakeowner";
+              }
+            });
+      }
+      if (allAttributes || attributeNames.contains("group")) {
+        results.put(
+            "group",
+            new GroupPrincipal() {
+              @Override
+              public String getName() {
+                return "fakegroup";
+              }
+
+              @Override
+              public String toString() {
+                return "fakegroup";
+              }
+            });
+      }
+      if (allAttributes || attributeNames.contains("permissions")) {
+        if (fileAttributes.isRegularFile()) {
+          results.put("permissions", EnumSet.of(OWNER_READ, OWNER_WRITE, GROUP_READ, GROUP_WRITE));
+        } else {
+          // Directories, Symlinks and Other:
+          results.put(
+              "permissions",
+              EnumSet.of(
+                  OWNER_READ, OWNER_WRITE, OWNER_EXECUTE, GROUP_READ, GROUP_WRITE, GROUP_EXECUTE));
+        }
+      }
     }
 
     // CloudStorageFileAttributes

--- a/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemTest.java
+++ b/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemTest.java
@@ -179,7 +179,7 @@ public class CloudStorageFileSystemTest {
       assertThat(fs.getRootDirectories()).containsExactly(fs.getPath("/"));
       assertThat(fs.getFileStores()).isEmpty();
       assertThat(fs.getSeparator()).isEqualTo("/");
-      assertThat(fs.supportedFileAttributeViews()).containsExactly("basic", "gcs");
+      assertThat(fs.supportedFileAttributeViews()).containsExactly("basic", "gcs", "posix");
     }
   }
 


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-storage-nio/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

This is the follow up patch after #1066 to add fake posix support in FileSystemProvider::readAttributes.
Important to note is that the values returned in this patch are all fixed and fake.

The main goal of this patch is to have minimal support for the posix attributes because some existing libraries fail if a filesystem does not support this at all. By adding faked support many of these libraries become usable in combination with cloud storage with minimal effort.

I expect that after this some may want to add a more accurate mapping of the attributes.

Fixes #1062 ☕️
