### PR TITLE
ci: javadoc as a required check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -18,6 +18,7 @@ branchProtectionRules:
       - OwlBot Post Processor
       - 'Kokoro - Test: Java GraalVM Native Image'
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
+      - javadoc
   - pattern: java7
     isAdminEnforced: true
     requiredApprovingReviewCount: 1


### PR DESCRIPTION
Manual configuration of the required check at Settings tab has been reverted. Adding that back via sync-repo-settings.yaml.
