### PR TITLE
fix: Add protection against a possible null dereference issue

### DIFF
--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/SeekableByteChannelPrefetcher.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/SeekableByteChannelPrefetcher.java
@@ -358,8 +358,8 @@ public final class SeekableByteChannelPrefetcher implements SeekableByteChannel 
       ensureFetching(blockIndex);
       candidate = fetching;
       if (candidate != null) {
-          buf = candidate.getBuf();
-          full.add(candidate);
+        buf = candidate.getBuf();
+        full.add(candidate);
       }
       fetching = null;
       ensureFetching(blockIndex + 1);

--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/SeekableByteChannelPrefetcher.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/SeekableByteChannelPrefetcher.java
@@ -357,8 +357,10 @@ public final class SeekableByteChannelPrefetcher implements SeekableByteChannel 
       nbMiss++;
       ensureFetching(blockIndex);
       candidate = fetching;
-      buf = candidate.getBuf();
-      full.add(candidate);
+      if (candidate != null) {
+          buf = candidate.getBuf();
+          full.add(candidate);
+      }
       fetching = null;
       ensureFetching(blockIndex + 1);
       return buf;


### PR DESCRIPTION
In file: SeekableByteChannelPrefetcher.java, class: `SeekableByteChannelPrefetcher`, there is a method fetch in which there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. 

In line 345 of SeekableByteChannelPrefetcher.java, we have 

        WorkUnit candidate=fetching;

Here fetching may be null. There is already hint at that in the null check in line 342. If `fetching` is null, we would have gone into the call to `ensureFetching`. Now this part is a grey area. The method is suggesting that it will ensure that `fetching` will have a value, but apparently, there may be ways to return from the function without updating the value of `fetching`. An example is line 309. 

Then again, In line 359, the variable `candidate` gets assigned.

        candidate=fetching;

At that point the `fetching` may be null (from line 349). So, in the next line when we have:

        buf=candidate.getBuf();

we may encounter a null pointer dereference. 


I introduced a null check in the appropriate path. Please review. 

Again the grey area is whether `ensureFetching` is always guaranteed to return a non-null value for `fetching`.

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.