### PR TITLE
chore: rely on shared-dependencies version from sdk-platform-java-config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.25.0</version>
+        <version>${google-cloud-shared-dependencies.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Follow-up to https://github.com/googleapis/java-storage-nio/pull/1357/. Closes #1366 
