### PR TITLE
fix: update CloudStorageFileSystemProvider#getFileAttributeView to return null rather than throw UnsupportedOperationException

### DIFF
--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
@@ -1017,6 +1017,7 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
   @Override
   public <V extends FileAttributeView> V getFileAttributeView(
       Path path, Class<V> type, LinkOption... options) {
+    checkNotNull(path);
     checkNotNull(type);
     CloudStorageUtil.checkNotNullArray(options);
     if (type != CloudStorageFileAttributeView.class && type != BasicFileAttributeView.class) {

--- a/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
+++ b/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageFileSystemProvider.java
@@ -1020,7 +1020,11 @@ public final class CloudStorageFileSystemProvider extends FileSystemProvider {
     checkNotNull(type);
     CloudStorageUtil.checkNotNullArray(options);
     if (type != CloudStorageFileAttributeView.class && type != BasicFileAttributeView.class) {
-      throw new UnsupportedOperationException(type.getSimpleName());
+      // the javadocs for getFileAttributeView specify the following for @return
+      //  a file attribute view of the specified type, or null if the attribute view type is not
+      //  available
+      // Similar type of issue from the JDK itself https://bugs.openjdk.org/browse/JDK-8273935
+      return null;
     }
     CloudStoragePath cloudPath = CloudStorageUtil.checkPath(path);
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Currently, when CloudStorageFileSystemProvider#getFileAttributeView is invoked with a class it doesn't recognize it throws an UnsupportedOperationException. The javadocs for FileSystemProvider, however specify that #getFileAttributeView[1] return null if the attribute view type is not available.

This change updates the behavior of CloudStorageFileSystemProvider#getFileAttributeView to return null rather than throw an exception.

Fixes #1424

[1] https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/nio/file/spi/FileSystemProvider.html#getFileAttributeView(java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption...)

