### PR TITLE
ci: google-cloud-nio-bom to list the artifact in from this repo

### DIFF
--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -16,4 +16,4 @@ jobs:
     - name: Unmanaged dependency check
       uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v3.32.0
       with:
-        bom-path: pom.xml
+        bom-path: google-cloud-nio-bom/pom.xml

--- a/google-cloud-nio-bom/pom.xml
+++ b/google-cloud-nio-bom/pom.xml
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-nio-bom</artifactId>
+    <version>0.127.21-SNAPSHOT</version><!-- {x-version-update:google-cloud-nio:current} -->
+    <packaging>pom</packaging>
+    <parent>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>sdk-platform-java-config</artifactId>
+        <version>3.32.0</version>
+        <relativePath/>
+    </parent>
+
+    <name>Google Cloud NIO BOM</name>
+    <url>https://github.com/googleapis/java-storage-nio</url>
+    <description>
+      BOM for Google Cloud NIO
+    </description>
+
+    <organization>
+      <name>Google LLC</name>
+    </organization>
+
+    <developers>
+      <developer>
+        <id>suztomo</id>
+        <name>Tomo Suzuki</name>
+        <email>suztomo@google.com</email>
+        <organization>Google LLC</organization>
+        <roles>
+          <role>Developer</role>
+        </roles>
+      </developer>
+    </developers>
+
+    <scm>
+      <connection>scm:git:https://github.com/googleapis/java-storage-nio.git</connection>
+      <developerConnection>scm:git:git@github.com:googleapis/java-storage-nio.git</developerConnection>
+      <url>https://github.com/googleapis/java-storage-nio</url>
+    </scm>
+
+
+    <licenses>
+      <license>
+        <name>The Apache Software License, Version 2.0</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        <distribution>repo</distribution>
+      </license>
+    </licenses>
+
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-nio</artifactId>
+          <version>0.127.21-SNAPSHOT</version><!-- {x-version-update:google-cloud-nio:current} -->
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+
+        <!-- Using maven site plugin only as a hook for javadoc:aggregate, don't need the reports -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+
+          <configuration>
+            <generateReports>false</generateReports>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
     <module>google-cloud-nio</module>
     <module>google-cloud-nio-retrofit</module>
     <module>google-cloud-nio-examples</module>
+    <module>google-cloud-nio-bom</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
Fixes https://github.com/googleapis/sdk-platform-java/issues/3063.

The unmanaged dependency check works with a BOM that lists the
artifacts published from a repository. The bom-path argument of
the workflow has been wrongly specified to the root pom.xml.

This pull request fixes the wrong argument by introducing the
google-cloud-nio-bom.

This is the same fix we applied for java-bigquery. In fact, this
change copies the google-cloud-bigquery-bom and modified the
artifact name and version.


With this pull request, I confirmed the unmanaged dependency check passes locally:

```
suztomo@suztomo2:~/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check$ mvn exec:java -Dexec.args="../pom.xml /usr/local/google/home/suztomo/java-storage-nio/google-cloud-nio-bom/pom.xml"
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------< com.google.cloud:unmanaged-dependency-check >-------------
[INFO] Building Unmanaged dependency check 0.0.1-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- exec-maven-plugin:3.3.0:java (default-cli) @ unmanaged-dependency-check ---
[]
...
```