### PR TITLE
chore: Update native-image.properties for failing build

### DIFF
--- a/google-cloud-nio/src/main/resources/META-INF/native-image/com/google/cloud/google-cloud-nio/native-image.properties
+++ b/google-cloud-nio/src/main/resources/META-INF/native-image/com/google/cloud/google-cloud-nio/native-image.properties
@@ -42,4 +42,5 @@ Args = --initialize-at-build-time=com.google.cloud.storage.contrib.nio.CloudStor
   com.google.common.io.BaseEncoding,\
   com.google.common.io.BaseEncoding$StandardBaseEncoding,\
   com.google.api.client.util.PemReader,\
+  jdk.internal.misc.InnocuousThread,\
   com.google.common.base.Charsets


### PR DESCRIPTION
Error: No instances of jdk.internal.misc.InnocuousThread are allowed in the image heap as this class should be initialized at image runtime. To see how this object got instantiated use --trace-object-instantiation=jdk.internal.misc.InnocuousThread.


