### PR TITLE
chore: set gcs-sdk-team as storage codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,11 +4,11 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/cloud-storage-dpe is the default owner for changes in this repo
-*                       @googleapis/yoshi-java @googleapis/cloud-storage-dpe
+# The @googleapis/gcs-sdk-team is the default owner for changes in this repo
+*                       @googleapis/yoshi-java @googleapis/gcs-sdk-team
 
 # for handwritten libraries, keep codeowner_team in .repo-metadata.json as owner
-**/*.java               @googleapis/cloud-storage-dpe
+**/*.java               @googleapis/gcs-sdk-team
 
 
 # The java-samples-reviewers team is the default owner for samples changes

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,5 +11,5 @@
   "distribution_name": "com.google.cloud:google-cloud-nio",
   "api_id": "storage.googleapis.com",
   "library_type": "OTHER",
-  "codeowner_team": "@googleapis/cloud-storage-dpe"
+  "codeowner_team": "@googleapis/gcs-sdk-team"
 }


### PR DESCRIPTION
clean up outdated cloud-storage-dpe team
