### PR TITLE
fix: remove explicit guava version from examples module

### DIFF
--- a/google-cloud-nio-examples/pom.xml
+++ b/google-cloud-nio-examples/pom.xml
@@ -19,7 +19,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>33.4.8-android</version>
     </dependency>
   </dependencies>
   <properties>


### PR DESCRIPTION
Use the version of guava from the parent